### PR TITLE
Add MIT license header with copyright to each script

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,19 @@
 Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/enemies/area_trigger.gd
+++ b/enemies/area_trigger.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 export(String) var group=""
 

--- a/enemies/cannon.gd
+++ b/enemies/cannon.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends StaticBody2D
 

--- a/enemies/enemy.gd
+++ b/enemies/enemy.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 extends RigidBody2D
 
 

--- a/enemies/explosion.gd
+++ b/enemies/explosion.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Particles2D
 

--- a/enemies/floating_spike.gd
+++ b/enemies/floating_spike.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends StaticBody2D
 

--- a/enemies/fluff.gd
+++ b/enemies/fluff.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/frog.gd
+++ b/enemies/frog.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/heatseeker.gd
+++ b/enemies/heatseeker.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/rb_spike.gd
+++ b/enemies/rb_spike.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends RigidBody2D
 

--- a/enemies/snake.gd
+++ b/enemies/snake.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/spikes.gd
+++ b/enemies/spikes.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends StaticBody2D
 

--- a/enemies/sporadic_flower.gd
+++ b/enemies/sporadic_flower.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/spore.gd
+++ b/enemies/spore.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/enemies/warrior.gd
+++ b/enemies/warrior.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/interaction/breakable_stone.gd
+++ b/interaction/breakable_stone.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends "res://enemies/enemy.gd"
 

--- a/interaction/bubble.gd
+++ b/interaction/bubble.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends RigidBody2D
 

--- a/interaction/carry_platform.gd
+++ b/interaction/carry_platform.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/interaction/elevator.gd
+++ b/interaction/elevator.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/interaction/fire_holder.gd
+++ b/interaction/fire_holder.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Sprite
 

--- a/interaction/ghost_push.gd
+++ b/interaction/ghost_push.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 extends "enemies/enemy.gd"
 
 # member variables here, example:

--- a/interaction/house.gd
+++ b/interaction/house.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends StaticBody2D
 

--- a/interaction/jar.gd
+++ b/interaction/jar.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends RigidBody2D
 

--- a/interaction/key.gd
+++ b/interaction/key.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends RigidBody2D
 

--- a/interaction/lock.gd
+++ b/interaction/lock.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/interaction/locked_door.gd
+++ b/interaction/locked_door.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/interaction/roulette.gd
+++ b/interaction/roulette.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/interaction/spinning_log.gd
+++ b/interaction/spinning_log.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends StaticBody2D
 

--- a/main.gd
+++ b/main.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 extends Node
 
 var current_child=null

--- a/menu/game_data.gd
+++ b/menu/game_data.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node
 

--- a/menu/main_menu.gd
+++ b/menu/main_menu.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends ReferenceFrame
 

--- a/menu/progress.gd
+++ b/menu/progress.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 var animation
 var ril
 

--- a/menu/stage_select.gd
+++ b/menu/stage_select.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends TextureFrame
 

--- a/player/alpaca.gd
+++ b/player/alpaca.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 extends RigidBody2D
 
 var jpart_names=["body/culete/rocket_fg/jetpack_a","body/culete/rocket_bg/jetpack_b"]

--- a/player/checkpoint.gd
+++ b/player/checkpoint.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Area2D
 

--- a/player/crosshair.gd
+++ b/player/crosshair.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node2D
 

--- a/player/fruit.gd
+++ b/player/fruit.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Area2D
 

--- a/player/goal.gd
+++ b/player/goal.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Area2D
 

--- a/player/heart.gd
+++ b/player/heart.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends RigidBody2D
 

--- a/player/hud.gd
+++ b/player/hud.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends ReferenceFrame
 

--- a/player/large_fruit.gd
+++ b/player/large_fruit.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Area2D
 

--- a/player/wise_alpaca.gd
+++ b/player/wise_alpaca.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Area2D
 

--- a/stages/stage.gd
+++ b/stages/stage.gd
@@ -1,3 +1,6 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 extends Node
 

--- a/stages/stage_list.gd
+++ b/stages/stage_list.gd
@@ -1,5 +1,6 @@
-
-
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
 
 static func get_stage_list():
 	

--- a/test.gd
+++ b/test.gd
@@ -1,3 +1,7 @@
+# This file is part of the Jetpaca game
+# Copyright (c) 2009-2016 Juan Linietsky, Ariel Manzur
+# Distributed under the terms of the MIT license (cf. LICENSE.md file)
+
 extends SceneMainLoop
 
 


### PR DESCRIPTION
Thus making it clearer that all the code is under the MIT license.

Also cropped the lines in the license file at ~80 characters.

Part of #1.
